### PR TITLE
Parse toplevel as a statement, includes declarations as statement too.

### DIFF
--- a/src/ast/declaration.h
+++ b/src/ast/declaration.h
@@ -5,10 +5,10 @@
 #include "util/option.h"
 
 namespace ast {
-class Declaration : public ASTNode {
+class Declaration : public Statement {
  public:
   Declaration(lexer::Range location, Identifier id, Option<Type> type)
-      : ASTNode(std::move(location)),
+      : Statement(std::move(location)),
         id_(std::move(id)),
         type_(std::move(type)) {}
   ~Declaration() override = default;

--- a/test/resources/parser/fail.gh
+++ b/test/resources/parser/fail.gh
@@ -1,3 +1,3 @@
   test
-//^^^^
-// ERROR: Expected top-level declaration
+//^ to EOF
+// ERROR: Expected `;' at the end of the statement


### PR DESCRIPTION
To discuss of course, the changes brings some questions:
- do we accept variables out of functions/classes/etc ?

I think that seeing a declaration as a statement is quite logic though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nitnelave/hopper/45)
<!-- Reviewable:end -->
