### PR TITLE
Fix compilation on mac: need to include libgen.h

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -1,3 +1,4 @@
+#include <libgen.h>
 #include <iostream>
 #include <string>
 


### PR DESCRIPTION
Compilation broken on mac, needs to include libgen.h to use the basename symbol in main

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nitnelave/hopper/52)
<!-- Reviewable:end -->
