### PR TITLE
Add visitor for variable destructions

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -23,6 +23,7 @@ enum class NodeType {
   RETURN_STATEMENT,
   SCOPE_BLOCK,
   UNARY_OP,
+  UNREACHABLE,
   VALUE_STATEMENT,
   VARIABLE_DESTRUCTION,
   VARIABLE_REFERENCE,
@@ -75,6 +76,7 @@ class Module;
 class ReturnStatement;
 // class ScopeBlock;
 // class UnaryOp;
+class UnreachableStatement;
 class ValueStatement;
 class VariableDestruction;
 class VariableReference;

--- a/src/ast/unreachable.h
+++ b/src/ast/unreachable.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ast/statement.h"
+#include "visitor/visitor.h"
+
+namespace ast {
+
+class UnreachableStatement : public Statement {
+ public:
+  explicit UnreachableStatement(lexer::Range range)
+      : Statement(std::move(range), NodeType::UNREACHABLE) {}
+
+  bool value() const { return value_; }
+
+ private:
+  void accept_impl(ASTVisitor& visitor) override { visitor.visit(this); }
+  bool value_;
+};
+}  // namespace ast

--- a/src/ast/value.h
+++ b/src/ast/value.h
@@ -12,6 +12,8 @@ class Value : public ASTNode {
       : ASTNode(std::move(location), node_type) {}
   ~Value() override = default;
 
+  const Option<Type>& type() const { return type_; }
+
   Option<Type>& type() { return type_; }
 
  private:

--- a/src/ast/variable_destruction.h
+++ b/src/ast/variable_destruction.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+
+#include "ast/statement.h"
+#include "ast/variable_declaration.h"
+#include "visitor/visitor.h"
+
+namespace ast {
+
+class VariableDestruction : public Statement {
+ public:
+  explicit VariableDestruction(VariableDeclaration* declaration)
+      : Statement(lexer::invalid_range(), NodeType::VARIABLE_DESTRUCTION),
+        declaration_(declaration) {}
+
+  VariableDeclaration* declaration() { return declaration_; }
+
+  ~VariableDestruction() override = default;
+
+ private:
+  void accept_impl(ASTVisitor& visitor) override { visitor.visit(this); }
+
+  VariableDeclaration* declaration_;
+};
+
+}  // namespace ast

--- a/src/codegen/codegen_statement.cc
+++ b/src/codegen/codegen_statement.cc
@@ -17,7 +17,8 @@ using namespace llvm;  // NOLINT
 void CodeGenerator::visit(ast::BlockStatement* node) {
   auto current_function = current_function_;
   for (auto const& statement : node->statements()) {
-    CHECK(!has_returned_);
+    CHECK(statement->node_type() == ast::NodeType::UNREACHABLE ||
+          !has_returned_);
     statement->accept(*this);
 
     // Restore state of node.

--- a/src/pretty_printer/pretty_printer.h
+++ b/src/pretty_printer/pretty_printer.h
@@ -13,6 +13,7 @@
 #include "ast/local_variable_declaration.h"
 #include "ast/module.h"
 #include "ast/return_statement.h"
+#include "ast/unreachable.h"
 #include "ast/value_statement.h"
 #include "ast/variable_reference.h"
 
@@ -95,6 +96,10 @@ class PrettyPrinterVisitor : public ASTVisitor {
       out_ << " else ";
       node->else_statement().value_or_die()->accept(*this);
     }
+  }
+
+  void visit(UnreachableStatement* /*unused*/) override {
+    out_ << "//unreachable//";
   }
 
   void visit(BlockStatement* node) override {

--- a/src/pretty_printer/pretty_printer.h
+++ b/src/pretty_printer/pretty_printer.h
@@ -15,6 +15,7 @@
 #include "ast/return_statement.h"
 #include "ast/unreachable.h"
 #include "ast/value_statement.h"
+#include "ast/variable_destruction.h"
 #include "ast/variable_reference.h"
 
 namespace ast {
@@ -100,6 +101,10 @@ class PrettyPrinterVisitor : public ASTVisitor {
 
   void visit(UnreachableStatement* /*unused*/) override {
     out_ << "//unreachable//";
+  }
+
+  void visit(VariableDestruction* node) override {
+    out_ << "//destroy " << node->declaration()->id().to_string() << "//";
   }
 
   void visit(BlockStatement* node) override {

--- a/src/transform/CMakeLists.txt
+++ b/src/transform/CMakeLists.txt
@@ -2,7 +2,9 @@ target_sources(${GRACC_LIBRARY}
     PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/function_value_body.cc"
         "${CMAKE_CURRENT_LIST_DIR}/add_return.cc"
+        "${CMAKE_CURRENT_LIST_DIR}/add_destroy_variable.cc"
     PUBLIC
         "${CMAKE_CURRENT_LIST_DIR}/function_value_body.h"
         "${CMAKE_CURRENT_LIST_DIR}/add_return.h"
+        "${CMAKE_CURRENT_LIST_DIR}/add_destroy_variable.h"
     )

--- a/src/transform/add_destroy_variable.cc
+++ b/src/transform/add_destroy_variable.cc
@@ -1,0 +1,80 @@
+#include "transform/add_destroy_variable.h"
+
+#include <iterator>
+
+#include "ast/block_statement.h"
+#include "ast/function_declaration.h"
+#include "ast/local_variable_declaration.h"
+#include "ast/variable_destruction.h"
+
+namespace transform {
+
+namespace {
+
+template <typename InsertIterator>
+InsertIterator destroy_variables_in_scope(
+    InsertIterator iter,
+    const VariableDestructorAdder::ScopeVariables& variables) {
+  for (auto it = variables.rbegin(); it != variables.rend(); ++it)
+    *iter = std::make_unique<ast::VariableDestruction>(*it);
+  return iter;
+}
+
+template <typename InsertIterator>
+InsertIterator destroy_all_variables(
+    InsertIterator iter,
+    const VariableDestructorAdder::ScopeStack& scope_stack) {
+  for (auto it = scope_stack.rbegin(); it != scope_stack.rend(); ++it)
+    iter = destroy_variables_in_scope(iter, *it);
+  return iter;
+}
+
+}  // namespace
+
+void VariableDestructorAdder::visit(ast::FunctionDeclaration* node) {
+  std::vector<ast::VariableDeclaration*> arguments;
+  for (const auto& arg : node->arguments()) {
+    arguments.emplace_back(arg.get());
+  }
+  visit_block(node->body()
+                  .get_unchecked<ast::FunctionDeclaration::StatementsBody>()
+                  .get(),
+              arguments);
+}
+
+void VariableDestructorAdder::visit_block(
+    ast::BlockStatement* node,
+    const std::vector<ast::VariableDeclaration*>& function_arguments) {
+  using ast::NodeType;
+  enter_scope();
+  std::move(function_arguments.begin(), function_arguments.end(),
+            std::back_inserter(current_scope()));
+  auto& statements = node->statements();
+  for (const auto& statement : statements) {
+    if (statement->node_type() == NodeType::LOCAL_VARIABLE_DECLARATION) {
+      // static_cast is safe because of the tag.
+      auto* var_decl = static_cast<ast::LocalVariableDeclaration*>(  // NOLINT
+          statement.get());
+      current_scope().emplace_back(var_decl);
+    }
+    statement->accept(*this);
+  }
+
+  auto last_type = statements.back()->node_type();
+  if (last_type == NodeType::RETURN_STATEMENT) {
+    // Insert the destruction nodes before the return statement.
+    destroy_all_variables(
+        std::inserter(statements, std::prev(statements.end())),
+        variables_in_scope_);
+  } else if (last_type != NodeType::UNREACHABLE) {
+    // If it's unreachable, no need to destroy the variables.
+    destroy_variables_in_scope(back_inserter(statements), current_scope());
+  }
+  exit_scope();
+}
+
+void VariableDestructorAdder::visit(ast::BlockStatement* node) {
+  visit_block(node);
+}
+
+}  // namespace transform

--- a/src/transform/add_destroy_variable.h
+++ b/src/transform/add_destroy_variable.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stack>
+#include <vector>
+
+#include "util/logging.h"
+#include "visitor/error_visitor.h"
+
+namespace transform {
+
+/// Add a destruction node for each variable when exiting a scope or returning
+/// from a function.
+class VariableDestructorAdder : public ast::VisitorWithErrors<> {
+ public:
+  using ScopeVariables = std::vector<ast::VariableDeclaration*>;
+  // Not using stacks because we need to access all scopes in case of a return.
+  using ScopeStack = std::vector<ScopeVariables>;
+  void visit(ast::FunctionDeclaration* node) override;
+  void visit(ast::BlockStatement* node) override;
+
+ private:
+  void enter_scope() { variables_in_scope_.emplace_back(); }
+
+  ScopeVariables& current_scope() {
+    CHECK(!variables_in_scope_.empty());
+    return variables_in_scope_.back();
+  }
+
+  void exit_scope() {
+    CHECK(!variables_in_scope_.empty());
+    variables_in_scope_.pop_back();
+  }
+
+  // Process a block, with potentially function arguments if it's the
+  // function's main body.
+  void visit_block(
+      ast::BlockStatement* node,
+      const std::vector<ast::VariableDeclaration*>& function_arguments = {});
+
+  ScopeStack variables_in_scope_;
+};
+}  // namespace transform

--- a/src/transform/add_return.cc
+++ b/src/transform/add_return.cc
@@ -5,6 +5,7 @@
 #include "ast/function_declaration.h"
 #include "ast/if_statement.h"
 #include "ast/return_statement.h"
+#include "ast/unreachable.h"
 #include "ast/variable_declaration.h"
 #include "util/logging.h"
 
@@ -55,6 +56,11 @@ void VoidFunctionReturnAdder::visit(ast::FunctionDeclaration* node) {
   if (has_returned_) {
     CHECK(!statements->statements().empty()) << "Empty function that returned: "
                                              << node->name();
+    if (statements->statements().back()->node_type() !=
+        ast::NodeType::RETURN_STATEMENT) {
+      statements->statements().emplace_back(
+          std::make_unique<ast::UnreachableStatement>(lexer::invalid_range()));
+    }
   } else {
     if (type.get_declaration() == &ast::types::void_type) {
       statements->statements().emplace_back(

--- a/src/typechecker/typechecker.cc
+++ b/src/typechecker/typechecker.cc
@@ -6,8 +6,10 @@
 #include "ast/builtin_type.h"
 #include "ast/function_declaration.h"
 #include "ast/int_constant.h"
+#include "ast/local_variable_declaration.h"
 #include "ast/return_statement.h"
 #include "ast/variable_reference.h"
+#include "util/logging.h"
 
 namespace typechecker {
 
@@ -70,8 +72,19 @@ void TypeChecker::visit(ast::BooleanConstant* node) {
   node->type() = Type(&ast::types::boolean);
 }
 
+ast::types::IntWidth smallest_int_width_for(int64_t value) {
+  using ast::types::IntWidth;
+  if (value >= (1l << 32)) return IntWidth::W_64;
+  if (value >= (1 << 16)) return IntWidth::W_32;
+  if (value >= (1 << 8)) return IntWidth::W_16;
+  return IntWidth::W_8;
+}
+
 void TypeChecker::visit(ast::IntConstant* node) {
-  node->type() = Type(&ast::types::int64);
+  if (node->value() >= (1l << 32))
+    node->type() = Type(&ast::types::int64);
+  else
+    node->type() = Type(&ast::types::int32);
 }
 
 void TypeChecker::visit(ast::BinaryOp* node) {
@@ -103,30 +116,58 @@ void TypeChecker::visit(ast::BinaryOp* node) {
   }
 }
 
+bool is_compatible(const ast::Type& declaration_type, const ast::Value* value) {
+  CHECK(value->type().is_ok());
+  const auto& value_type = value->type().value_or_die();
+  if (declaration_type == value_type) return true;
+  if (is_integer(declaration_type) && is_integer(value_type)) {
+    auto actual_width =
+        ast::types::int_type_to_width(value_type.get_declaration())
+            .value_or_die();
+    if (value->node_type() == ast::NodeType::INT_CONSTANT) {
+      const auto* constant =
+          static_cast<const ast::IntConstant*>(value);  // NOLINT
+      actual_width = smallest_int_width_for(constant->value());
+    }
+    return ast::types::int_type_to_width(declaration_type.get_declaration())
+               .value_or_die() >= actual_width;
+  }
+  return false;
+}
+
 void TypeChecker::visit(ast::ReturnStatement* node) {
   size_t num_errors = error_list().errors().size();
   ASTVisitor::visit(node);
   if (num_errors < error_list().errors().size()) return;
 
-  const Type value_type = [&]() {
-    if (node->value().is_ok()) {
-      const auto& maybe_type = node->value().value_or_die()->type();
-      assert(maybe_type.is_ok());
-      return maybe_type.value_or_die();
+  auto add_type_error = [&](const auto& value_type) {
+    add_error(node->location(),
+              "Invalid return type: the function returns `" +
+                  function_return_type_.value_or_die().to_string() +
+                  "', but the return value is of type `" +
+                  value_type.to_string() + "'");
+  };
+
+  if (node->value().is_ok()) {
+    auto* value = node->value().value_or_die().get();
+    CHECK(value->type().is_ok());
+    const auto& value_type = value->type().value_or_die();
+    if (function_return_type_.is_ok()) {
+      if (!is_compatible(function_return_type_.value_or_die(), value)) {
+        add_type_error(value_type);
+        return;
+      }
+    } else {
+      function_return_type_ = value_type;
     }
-    return Type(&ast::types::void_type);
-  }();
-  if (function_return_type_.is_ok()) {
-    if (function_return_type_.value_or_die() != value_type) {
-      add_error(node->location(),
-                "Invalid return type: the function returns `" +
-                    function_return_type_.value_or_die().to_string() +
-                    "', but the return value is of type `" +
-                    value_type.to_string() + "'");
-      return;
+  } else {
+    using ast::types::void_type;
+    if (function_return_type_.is_ok() &&
+        function_return_type_.value_or_die().get_declaration() != &void_type) {
+      add_type_error(void_type.id());
     }
+    function_return_type_ = Type(&void_type);
   }
-  function_return_type_ = value_type;
 }
 
 void TypeChecker::visit(ast::FunctionDeclaration* node) {
@@ -145,6 +186,31 @@ void TypeChecker::visit(ast::FunctionDeclaration* node) {
   if (!function_return_type_.is_ok())
     function_return_type_ = Type(&ast::types::void_type);
   node->type() = function_return_type_;
+}
+
+void TypeChecker::visit(ast::LocalVariableDeclaration* node) {
+  ASTVisitor::visit(node);
+  if (node->value().is_ok()) {
+    CHECK(node->value().value_or_die()->type().is_ok());
+    const auto& value_type =
+        node->value().value_or_die()->type().value_or_die();
+    if (node->type().is_ok()) {
+      const auto& node_type = node->type().value_or_die();
+      if (!is_compatible(node_type, node->value().value_or_die().get())) {
+        add_error(node->location(),
+                  "Invalid variable declaration: a variable of type `" +
+                      node_type.to_string() +
+                      "' cannot contain a value of type `" +
+                      value_type.to_string() + "'");
+        return;
+      }
+    } else {
+      node->type() = value_type;
+    }
+  } else {
+    CHECK(node->type().is_ok())
+        << "Variable declaration with no type and no value?";
+  }
 }
 
 }  // namespace typechecker

--- a/src/typechecker/typechecker.h
+++ b/src/typechecker/typechecker.h
@@ -19,6 +19,7 @@ class TypeChecker : public ast::VisitorWithErrors<> {
   void visit(ast::FunctionDeclaration* node) override;
   void visit(ast::ReturnStatement* node) override;
   void visit(ast::VariableReference* node) override;
+  void visit(ast::LocalVariableDeclaration* node) override;
 
  private:
   // We may have to turn that into a stack to support nested functions.

--- a/src/visitor/visitor.cc
+++ b/src/visitor/visitor.cc
@@ -50,6 +50,7 @@ void ASTVisitor::visit(LocalVariableDeclaration* node) {
   if (node->value().is_ok()) node->value().value_or_die()->accept(*this);
 }
 void ASTVisitor::visit(VariableReference* /*unused*/) {}
+void ASTVisitor::visit(UnreachableStatement* /*unused*/) {}
 
 void ASTVisitor::visit(BlockStatement* node) {
   for (const auto& statement : node->statements()) {

--- a/src/visitor/visitor.cc
+++ b/src/visitor/visitor.cc
@@ -60,4 +60,6 @@ void ASTVisitor::visit(BlockStatement* node) {
 
 void ASTVisitor::visit(ValueStatement* node) { node->value()->accept(*this); }
 
+void ASTVisitor::visit(VariableDestruction* /*unused*/) {}
+
 }  // namespace ast

--- a/src/visitor/visitor.h
+++ b/src/visitor/visitor.h
@@ -24,6 +24,7 @@ class ASTVisitor {
   virtual void visit(UnreachableStatement* node);
   virtual void visit(ValueStatement* node);
   virtual void visit(VariableReference* node);
+  virtual void visit(VariableDestruction* node);
 };
 
 }  // namespace ast

--- a/src/visitor/visitor.h
+++ b/src/visitor/visitor.h
@@ -21,6 +21,7 @@ class ASTVisitor {
   virtual void visit(LocalVariableDeclaration* node);
   virtual void visit(Module* node);
   virtual void visit(ReturnStatement* node);
+  virtual void visit(UnreachableStatement* node);
   virtual void visit(ValueStatement* node);
   virtual void visit(VariableReference* node);
 };

--- a/test/resources/resources.cc
+++ b/test/resources/resources.cc
@@ -13,6 +13,7 @@
 #include "test_utils/files.h"
 #include "test_utils/lexing.h"
 #include "test_utils/utils.h"
+#include "transform/add_destroy_variable.h"
 #include "transform/add_return.h"
 #include "transform/function_value_body.h"
 #include "typechecker/typechecker.h"
@@ -375,6 +376,15 @@ TEST(ResourcesTest, VoidFunctionReturnAdder) {
           transformer_test<get_transformed_pretty_printed_file<
               name_resolution::NameResolver, typechecker::TypeChecker,
               transform::VoidFunctionReturnAdder>>>("transformer/add_return")));
+}
+
+TEST(ResourcesTest, AddDestroyVariable) {
+  EXPECT_TRUE((test_all_files_in_dir<
+               transformer_test<get_transformed_pretty_printed_file<
+                   name_resolution::NameResolver, typechecker::TypeChecker,
+                   transform::VoidFunctionReturnAdder,
+                   transform::VariableDestructorAdder>>>(
+      "transformer/destroy_variable")));
 }
 
 TEST(ResourcesTest, CodeGenerator) {

--- a/test/resources/transformer/add_return/simple_add_return.ref
+++ b/test/resources/transformer/add_return/simple_add_return.ref
@@ -16,10 +16,10 @@ fun test4() : Void {
   (1 + 2);
   return;
 }
-fun test5() : Int64 {
+fun test5() : Int32 {
   return 3;
 }
-fun test6() : Int64 {
+fun test6() : Int32 {
   if (true) {
     return 3;
   } else {

--- a/test/resources/transformer/add_return/simple_add_return.ref
+++ b/test/resources/transformer/add_return/simple_add_return.ref
@@ -10,6 +10,7 @@ fun test3() : Void {
   {
     return;
   }
+  //unreachable//
 }
 fun test4() : Void {
   (1 + 2);
@@ -24,4 +25,5 @@ fun test6() : Int64 {
   } else {
     return 4;
   }
+  //unreachable//
 }

--- a/test/resources/transformer/destroy_variable/arguments.gh
+++ b/test/resources/transformer/destroy_variable/arguments.gh
@@ -1,0 +1,12 @@
+fun toto(val arg1 : Int32, val arg2 : Int8) {
+  val a = 3;
+  if (true) {
+    val b = 2;
+    {
+      val d = 3;
+    }
+    return;
+  }
+  val c = 1;
+  return;
+}

--- a/test/resources/transformer/destroy_variable/arguments.ref
+++ b/test/resources/transformer/destroy_variable/arguments.ref
@@ -1,0 +1,21 @@
+fun toto(val arg1: Int32, val arg2: Int8) : Void {
+  val a : Int32 = 3;
+  if (true) {
+    val b : Int32 = 2;
+    {
+      val d : Int32 = 3;
+      //destroy d//
+    }
+    //destroy b//
+    //destroy a//
+    //destroy arg2//
+    //destroy arg1//
+    return;
+  }
+  val c : Int32 = 1;
+  //destroy c//
+  //destroy a//
+  //destroy arg2//
+  //destroy arg1//
+  return;
+}

--- a/test/resources/transformer/destroy_variable/conditional_return.gh
+++ b/test/resources/transformer/destroy_variable/conditional_return.gh
@@ -1,0 +1,9 @@
+fun main() {
+  val a = 3;
+  if (true) {
+    val b = 2;
+    return;
+  }
+  val c = 1;
+  return;
+}

--- a/test/resources/transformer/destroy_variable/conditional_return.ref
+++ b/test/resources/transformer/destroy_variable/conditional_return.ref
@@ -1,0 +1,13 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  if (true) {
+    val b : Int32 = 2;
+    //destroy b//
+    //destroy a//
+    return;
+  }
+  val c : Int32 = 1;
+  //destroy c//
+  //destroy a//
+  return;
+}

--- a/test/resources/transformer/destroy_variable/destroy_scope.gh
+++ b/test/resources/transformer/destroy_variable/destroy_scope.gh
@@ -1,0 +1,11 @@
+fun main() {
+  val a = 3;
+  val b = 3;
+  {
+    val c = 4;
+    val d = 5;
+    {
+      val e = 6;
+    }
+  }
+}

--- a/test/resources/transformer/destroy_variable/destroy_scope.ref
+++ b/test/resources/transformer/destroy_variable/destroy_scope.ref
@@ -1,0 +1,17 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  val b : Int32 = 3;
+  {
+    val c : Int32 = 4;
+    val d : Int32 = 5;
+    {
+      val e : Int32 = 6;
+      //destroy e//
+    }
+    //destroy d//
+    //destroy c//
+  }
+  //destroy b//
+  //destroy a//
+  return;
+}

--- a/test/resources/transformer/destroy_variable/destroy_scope_return.gh
+++ b/test/resources/transformer/destroy_variable/destroy_scope_return.gh
@@ -1,0 +1,12 @@
+fun main() {
+  val a = 3;
+  val b = 3;
+  {
+    val c = 4;
+    val d = 5;
+    {
+      val e = 6;
+    }
+    return;
+  }
+}

--- a/test/resources/transformer/destroy_variable/destroy_scope_return.ref
+++ b/test/resources/transformer/destroy_variable/destroy_scope_return.ref
@@ -1,0 +1,18 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  val b : Int32 = 3;
+  {
+    val c : Int32 = 4;
+    val d : Int32 = 5;
+    {
+      val e : Int32 = 6;
+      //destroy e//
+    }
+    //destroy d//
+    //destroy c//
+    //destroy b//
+    //destroy a//
+    return;
+  }
+  //unreachable//
+}

--- a/test/resources/transformer/destroy_variable/destroy_two.gh
+++ b/test/resources/transformer/destroy_variable/destroy_two.gh
@@ -1,0 +1,4 @@
+fun main() {
+  val a = 3;
+  val b = 2;
+}

--- a/test/resources/transformer/destroy_variable/destroy_two.ref
+++ b/test/resources/transformer/destroy_variable/destroy_two.ref
@@ -1,0 +1,7 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  val b : Int32 = 2;
+  //destroy b//
+  //destroy a//
+  return;
+}

--- a/test/resources/transformer/destroy_variable/simple.gh
+++ b/test/resources/transformer/destroy_variable/simple.gh
@@ -1,0 +1,3 @@
+fun main() {
+  val a = 3;
+}

--- a/test/resources/transformer/destroy_variable/simple.ref
+++ b/test/resources/transformer/destroy_variable/simple.ref
@@ -1,0 +1,5 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  //destroy a//
+  return;
+}

--- a/test/resources/type_checker/function_return.ref
+++ b/test/resources/type_checker/function_return.ref
@@ -3,7 +3,7 @@ fun test1() : Void {
 fun test2() : Void {
   return;
 }
-fun test3() : Int64 {
+fun test3() : Int32 {
   return 3;
   return 5;
 }

--- a/test/resources/type_checker/invalid_binary_op.gh
+++ b/test/resources/type_checker/invalid_binary_op.gh
@@ -1,3 +1,3 @@
 fun test() = 2 + true;
 //           ^^^^^^^^
-// ERROR: Invalid operand types for binary operation `+': `Int64' and `Bool'
+// ERROR: Invalid operand types for binary operation `+': `Int32' and `Bool'

--- a/test/resources/type_checker/invalid_int_conversion.gh
+++ b/test/resources/type_checker/invalid_int_conversion.gh
@@ -1,0 +1,32 @@
+fun main() {
+  val a : Int8 = 300;
+//^^^^^^^^^^^^^^^^^^
+// ERROR: Invalid variable declaration: a variable of type `Int8' cannot contain a value of type `Int32'
+  val b : Int16 = 70000;
+//^^^^^^^^^^^^^^^^^^^^^
+// ERROR: Invalid variable declaration: a variable of type `Int16' cannot contain a value of type `Int32'
+  val c : Int32 = 5000000000;
+//^^^^^^^^^^^^^^^^^^^^^^^^^^
+// ERROR: Invalid variable declaration: a variable of type `Int32' cannot contain a value of type `Int64'
+}
+
+fun test1() : Int8 {
+  if (true)
+    return 3;
+  else
+    return 300;
+//  ^^^^^^^^^^^
+// ERROR: Invalid return type: the function returns `Int8', but the return value is of type `Int32'
+}
+
+fun test2() : Int16 {
+  return 70000;
+//^^^^^^^^^^^^^
+// ERROR: Invalid return type: the function returns `Int16', but the return value is of type `Int32'
+}
+
+fun test3() : Int32 {
+  return 5000000000;
+//^^^^^^^^^^^^^^^^^^
+// ERROR: Invalid return type: the function returns `Int32', but the return value is of type `Int64'
+}

--- a/test/resources/type_checker/invalid_return_type.gh
+++ b/test/resources/type_checker/invalid_return_type.gh
@@ -1,5 +1,5 @@
 fun test() : Bool {
   return 3;
 //^^^^^^^^^
-// ERROR: Invalid return type: the function returns `Bool', but the return value is of type `Int64'
+// ERROR: Invalid return type: the function returns `Bool', but the return value is of type `Int32'
 }

--- a/test/resources/type_checker/valid_binary_op.ref
+++ b/test/resources/type_checker/valid_binary_op.ref
@@ -1,4 +1,4 @@
-fun test() : Int64 {
+fun test() : Int32 {
   return (2 + 3);
 }
 fun test2() : Bool {

--- a/test/resources/type_checker/variable_decl.gh
+++ b/test/resources/type_checker/variable_decl.gh
@@ -1,0 +1,10 @@
+fun main() {
+  val a = 3;
+  val b : Int64 = 3;
+  val c : Int32 = 3;
+  val d : Int16 = 3;
+  val e : Int8 = 3;
+  val f : Int16 = 300;
+  val g : Int32 = 70000;
+  val h : Int64 = 5000000000;
+}

--- a/test/resources/type_checker/variable_decl.ref
+++ b/test/resources/type_checker/variable_decl.ref
@@ -1,0 +1,10 @@
+fun main() : Void {
+  val a : Int32 = 3;
+  val b : Int64 = 3;
+  val c : Int32 = 3;
+  val d : Int16 = 3;
+  val e : Int8 = 3;
+  val f : Int16 = 300;
+  val g : Int32 = 70000;
+  val h : Int64 = 5000000000;
+}


### PR DESCRIPTION
This PR starts by expanding the visitor that add returns to also add "unreachable" nodes, where the control flow cannot get.

Then the typechecker's handling of ints is improved.

And finally, a visitor adding "destruction nodes" for variables leaving the scope or before a return is added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nitnelave/hopper/62)
<!-- Reviewable:end -->
